### PR TITLE
Updated battery check to use native-path upower property.

### DIFF
--- a/src/upower/provider_upower.cpp
+++ b/src/upower/provider_upower.cpp
@@ -87,7 +87,7 @@ void Bridge::update_all_props()
 bool Bridge::try_get_battery(QString const &path)
 {
     auto is_battery = [](std::unique_ptr<Device> const &p) {
-        return ((DeviceType)p->type() == Battery);
+        return (p->nativePath() == "battery");
     };
     std::unique_ptr<Device> device(new Device(service_name, path, bus_));
     if (!is_battery(device))


### PR DESCRIPTION
Signed-off-by: Tom Swindell t.swindell@rubyx.co.uk
