### PR TITLE
[ofono] fixed wrong order of network state connected flags

### DIFF
--- a/src/ofono/provider_ofono.cpp
+++ b/src/ofono/provider_ofono.cpp
@@ -262,7 +262,8 @@ static const status_array_type ofono_status_ = {{
     , "searching", "denied", "unknown", "roaming"
     }};
 
-static const std::bitset<size_t(Status::EOE)> status_registered_("0010001");
+// read in big endian
+static const std::bitset<size_t(Status::EOE)> status_registered_("1000100");
 
 static const std::map<QString, QString> sim_props_map_ = {
     { "MobileCountryCode", "HomeMCC" }


### PR DESCRIPTION
std::bitset character string initialization is big endian.
Signed-off-by: Denis Zalevskiy denis.zalevskiy@jolla.com
