### PR TITLE
[bluez] use source name for default properties instead of destination

### DIFF
--- a/src/bluez/provider_bluez.cpp
+++ b/src/bluez/provider_bluez.cpp
@@ -141,8 +141,8 @@ BlueZ::BlueZ(QDBusConnection &bus)
     : Namespace("Bluetooth", std::unique_ptr<PropertiesSource>
                 (new Bridge(this, bus)))
     , defaults_({
-            { "Enabled", "0" }
-            , { "Visible", "0" }
+            { "Powered", "0" }
+            , { "Discoverable", "0" }
             , { "Connected", "0" }
             , { "Address", "00:00:00:00:00:00" }})
 {


### PR DESCRIPTION
Otherwise property is not reset to default because corresponding
setter is not found

Signed-off-by: Denis Zalevskiy denis.zalevskiy@jolla.com
