### PR TITLE
[back_cover] add open() to satisfy new statefs-pp api

### DIFF
--- a/rpm/statefs-providers.spec
+++ b/rpm/statefs-providers.spec
@@ -8,7 +8,7 @@
 %define maemo_ver1 0.7.31
 %define meego_ver 0.1.0
 %define meego_ver1 0.1.0.1
-%define statefs_ver 0.3.27
+%define statefs_ver 0.3.28
 
 Summary: Statefs providers
 Name: statefs-providers

--- a/rpm/statefs-providers.spec.tpl
+++ b/rpm/statefs-providers.spec.tpl
@@ -8,7 +8,7 @@
 %define maemo_ver1 0.7.31
 %define meego_ver 0.1.0
 %define meego_ver1 0.1.0.1
-%define statefs_ver 0.3.27
+%define statefs_ver 0.3.28
 
 Summary: Statefs providers
 Name: statefs-providers

--- a/src/back_cover/provider_back_cover.cpp
+++ b/src/back_cover/provider_back_cover.cpp
@@ -73,6 +73,7 @@ class BackCoverMonitor {
 public:
     BackCoverMonitor(statefs::AProperty *parent);
 
+    int open(int);
     int getattr() const;
     ssize_t size() const;
     bool connect(statefs_slot *slot);
@@ -188,7 +189,7 @@ int BackCoverMonitor::findDevice()
             throw;
         }
 
-        int fd = open(s.str().c_str(), O_RDONLY);
+        int fd = ::open(s.str().c_str(), O_RDONLY);
         if (fd == -1) {
             std::cerr << "Failed to check " << entry->d_name << std::endl;
             continue;
@@ -207,6 +208,11 @@ int BackCoverMonitor::findDevice()
     std::cerr << "Could not find toh event device" << std::endl;
 
     return -1;
+}
+
+int BackCoverMonitor::open(int flags)
+{
+    return (flags & (O_WRONLY | O_TRUNC)) ? -EINVAL : 0;
 }
 
 int BackCoverMonitor::getattr() const


### PR DESCRIPTION
There was no changes in statefs-pp soversion because there are no providers
living outside statefs-providers repository yet

Signed-off-by: Denis Zalevskiy <denis.zalevskiy@jolla.com>