### PR TITLE
Fix for statefs::udev::KeyboardNs::~KeyboardNs() crash

### DIFF
--- a/src/keyboard_generic/provider_keyboard_generic.cpp
+++ b/src/keyboard_generic/provider_keyboard_generic.cpp
@@ -155,7 +155,7 @@ KeyboardNs::~KeyboardNs()
 {
     TRACE() << "Stopping I/O" << std::endl;
     io_.stop();
-    monitor_thread_->join();
+    if (monitor_thread_) monitor_thread_->join();
 }
 
 Monitor::Action KeyboardNs::on_input_device(udevpp::Device &&dev)


### PR DESCRIPTION
To reproduce the crash, run

 statefs register /usr/lib/statefs/libprovider-keyboard_generic.so --statefs-type=default --system